### PR TITLE
Fix buggy index splitting: don't return indices with less than 1 key

### DIFF
--- a/src/Data/BTree/Primitives/Index.hs
+++ b/src/Data/BTree/Primitives/Index.hs
@@ -115,13 +115,15 @@ extendIndexPred p f = go
         | let indexEnc = f index
         , p indexEnc
         = Just (singletonIndex indexEnc)
+        | indexNumKeys index <= 2
+        = error "cannot split node with only 2 keys, increase page size"
         | otherwise
         = do
             let numKeys = indexNumKeys index
             (leftEnc, (middleKey, right)) <- safeLast $
                 takeWhile (p . fst)
                 [ (leftEnc, (middleKey, right))
-                | i <- [1..numKeys-1]
+                | i <- [1..numKeys-2] -- left and right must contain at least one key
                 , let (left,middleKey,right) = splitIndexAt i index
                       leftEnc                = f left
                 ]

--- a/src/Data/BTree/Store/Binary.hs
+++ b/src/Data/BTree/Store/Binary.hs
@@ -205,7 +205,7 @@ instance (Ord fp, Applicative m, Monad m) =>
     nodePageSize tx = return $ \h ->
         fromIntegral . BL.length . B.runPut . putPage . PageNode tx h
 
-    maxPageSize = return 256
+    maxPageSize = return 128
 
     setSize fp (PageCount n) = StoreT $ do
         let emptyFile = M.fromList

--- a/tests/Properties/Primitives/Ids.hs
+++ b/tests/Properties/Primitives/Ids.hs
@@ -17,7 +17,10 @@ import Properties.Utils (testBinary)
 
 instance Arbitrary PageSize where
     arbitrary = PageSize . fromIntegral <$> elements pows
-      where pows = ((2 :: Int) ^) <$> ([6..12] :: [Int])
+      where
+        -- minimum page size is 128 (fits at
+        -- least two keys in an index node)
+        pows = ((2 :: Int) ^) <$> ([7..12] :: [Int])
 
 deriving instance Arbitrary (NodeId height key val)
 deriving instance Arbitrary PageId


### PR DESCRIPTION
- [x] includes tests
- [x] ready for review
- [x] reviewed by @hverr


#### What does this PR do?
- Increase effectiveness of write-open-read integration test
- Increase minimum page size in tests
- Fix bug in `extendIndexPred` which was splitting index nodes by returning subnodes without a key (and thus breaking the minimum amount of keys invariant for index nodes, on which the delete and merge functions rely on.

#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
