### PR TITLE
Track (in-memory) and reuse freed pages in a write transaction

### DIFF
--- a/src/Data/BTree/Alloc/Append.hs
+++ b/src/Data/BTree/Alloc/Append.hs
@@ -136,19 +136,14 @@ runAppendT :: AppendMetaStoreM hnd m => AppendT env m a -> env hnd -> m a
 runAppendT m = evalStateT (fromAppendT m)
 
 instance AllocWriterM (AppendT WriterEnv m) where
-    readNodeTxId height nid = AppendT $ do
-        hnd <- writerHnd <$> get
-        getNodePage hnd height Proxy Proxy nid
-
-    nodePageSize = currentTxId >>= \tx ->
-        AppendT (Store.nodePageSize tx)
+    nodePageSize = AppendT Store.nodePageSize
 
     maxPageSize = AppendT Store.maxPageSize
 
-    allocNode height n = currentTxId >>= \tx -> AppendT $ do
+    allocNode height n = AppendT $ do
         hnd <- writerHnd <$> get
         nid <- getNid
-        putNodePage hnd tx height nid n
+        putNodePage hnd height nid n
         return nid
       where
         getNid :: AppendMetaStoreM hnd m
@@ -164,9 +159,9 @@ instance AllocWriterM (AppendT WriterEnv m) where
                 return $ pageIdToNodeId x
 
 
-    writeNode nid height n = currentTxId >>= \tx -> AppendT $ do
+    writeNode nid height n = AppendT $ do
         hnd <- writerHnd <$> get
-        putNodePage hnd tx height nid n
+        putNodePage hnd height nid n
         return nid
 
     freeNode _ nid = AppendT $ modify $ \env ->
@@ -177,12 +172,12 @@ instance AllocWriterM (AppendT WriterEnv m) where
 instance AllocReaderM (AppendT WriterEnv m) where
     readNode height nid = AppendT $ do
         hnd <- writerHnd <$> get
-        fst <$> getNodePage hnd height Proxy Proxy nid
+        getNodePage hnd height Proxy Proxy nid
 
 instance AllocReaderM (AppendT ReaderEnv m) where
     readNode height nid = AppendT $ do
         hnd <- readerHnd <$> get
-        fst <$> getNodePage hnd height Proxy Proxy nid
+        getNodePage hnd height Proxy Proxy nid
 
 --------------------------------------------------------------------------------
 

--- a/src/Data/BTree/Alloc/Class.hs
+++ b/src/Data/BTree/Alloc/Class.hs
@@ -32,13 +32,6 @@ class (Applicative m, Monad m) => AllocWriterM m where
     {-| The maximum page size the allocator can handle. -}
     maxPageSize  ::  m PageSize
 
-    {-| Read a page and return the actual node and the transaction id this
-       node was written at. -}
-    readNodeTxId :: (Key key, Value val)
-                 => Height height
-                 -> NodeId height key val
-                 -> m (Node height key val, TxId)
-
     {-| Allocate a new page for a node, and write the node to the page. -}
     allocNode    :: (Key key, Value val)
                  => Height height

--- a/src/Data/BTree/Primitives/Ids.hs
+++ b/src/Data/BTree/Primitives/Ids.hs
@@ -43,6 +43,10 @@ newtype NodeId (height :: Nat) key val = NodeId { fromNodeId :: Word64 }
 nodeIdToPageId :: NodeId height key val -> PageId
 nodeIdToPageId = PageId . fromNodeId
 
+{-| Convert a 'PageId' to a 'NodeId' -}
+pageIdToNodeId :: PageId -> NodeId height key val
+pageIdToNodeId = NodeId . fromPageId
+
 {-| Transaction ids that are used as revision numbers. -}
 newtype TxId = TxId { fromTxId :: Word64 }
   deriving (Eq, Ord, Binary, Num, Value, Key, Typeable)

--- a/src/Data/BTree/Store/Class.hs
+++ b/src/Data/BTree/Store/Class.hs
@@ -22,8 +22,7 @@ class (Applicative m, Monad m) => StoreM hnd m | m -> hnd where
     {-| A function that calculates the hypothetical size of a node, if it were
        to be written to a page (regardless of the maximum page size). -}
     nodePageSize :: (Key key, Value val)
-                 => TxId
-                 -> m (Height height -> Node height key val -> PageSize)
+                 => m (Height height -> Node height key val -> PageSize)
 
     {-| The maximum page size the allocator can handle. -}
     maxPageSize  :: m PageSize
@@ -42,31 +41,30 @@ class (Applicative m, Monad m) => StoreM hnd m | m -> hnd where
                  -> Proxy key
                  -> Proxy val
                  -> NodeId height key val
-                 -> m (Node height key val, TxId)
+                 -> m (Node height key val)
 
     {-| Write a node to a physical page. -}
     putNodePage  :: (Key key, Value val)
                  => hnd
-                 -> TxId
                  -> Height height
                  -> NodeId height key val
                  -> Node height key val
                  -> m ()
 
 instance StoreM hnd m => StoreM hnd (StateT s m) where
-    nodePageSize = lift.             nodePageSize
+    nodePageSize = lift              nodePageSize
     maxPageSize  = lift              maxPageSize
     setSize      = (lift.).          setSize
     getSize      = lift.             getSize
     getNodePage  = ((((lift.).).).). getNodePage
-    putNodePage  = ((((lift.).).).). putNodePage
+    putNodePage  = (((lift.).).).    putNodePage
 
 instance StoreM hnd m => StoreM hnd (ReaderT s m) where
-    nodePageSize = lift.             nodePageSize
+    nodePageSize = lift              nodePageSize
     maxPageSize  = lift              maxPageSize
     setSize      = (lift.).          setSize
     getSize      = lift.             getSize
     getNodePage  = ((((lift.).).).). getNodePage
-    putNodePage  = ((((lift.).).).). putNodePage
+    putNodePage  = (((lift.).).).    putNodePage
 
 --------------------------------------------------------------------------------

--- a/tests/Properties/Store/Binary.hs
+++ b/tests/Properties/Store/Binary.hs
@@ -25,20 +25,20 @@ prop_binary_pageEmpty = case decode getEmptyPage (encode PageEmpty) of
     PageEmpty -> True
     _         -> False
 
-prop_binary_pageNode_leaf :: TxId -> Property
-prop_binary_pageNode_leaf tx = forAll genLeafNode $ \leaf ->
-    case decode (getPageNode zeroHeight key val) (encode (PageNode tx zeroHeight leaf)) of
-        PageNode _ h n -> maybe False (== leaf) $ castNode h zeroHeight n
-        _              -> False
+prop_binary_pageNode_leaf :: Property
+prop_binary_pageNode_leaf = forAll genLeafNode $ \leaf ->
+    case decode (getPageNode zeroHeight key val) (encode (PageNode zeroHeight leaf)) of
+        PageNode h n -> maybe False (== leaf) $ castNode h zeroHeight n
+        _            -> False
  where
    key = Proxy :: Proxy Int64
    val = Proxy :: Proxy Bool
 
-prop_binary_pageNode_idx :: TxId -> Property
-prop_binary_pageNode_idx tx = forAll genIndexNode $ \(srcHgt, idx) ->
-    case decode (getPageNode srcHgt key val) (encode (PageNode tx srcHgt idx)) of
-        PageNode _ h n -> maybe False (== idx) $ castNode h srcHgt n
-        _              -> False
+prop_binary_pageNode_idx :: Property
+prop_binary_pageNode_idx = forAll genIndexNode $ \(srcHgt, idx) ->
+    case decode (getPageNode srcHgt key val) (encode (PageNode srcHgt idx)) of
+        PageNode h n -> maybe False (== idx) $ castNode h srcHgt n
+        _            -> False
  where
    key = Proxy :: Proxy Int64
    val = Proxy :: Proxy Bool

--- a/tests/Properties/Store/File.hs
+++ b/tests/Properties/Store/File.hs
@@ -38,24 +38,24 @@ prop_binary_pageEmpty ps
         _         -> False
     | otherwise = False -- should always work
 
-prop_binary_pageNode_leaf :: PageSize -> TxId -> Property
-prop_binary_pageNode_leaf ps tx = forAll genLeafNode $ \leaf ->
-    case encodeAndPad ps (PageNode tx zeroHeight leaf) of
+prop_binary_pageNode_leaf :: PageSize -> Property
+prop_binary_pageNode_leaf ps = forAll genLeafNode $ \leaf ->
+    case encodeAndPad ps (PageNode zeroHeight leaf) of
         Nothing -> True -- too big, skip
         Just bs -> case decode (getPageNode zeroHeight key val) bs of
-            PageNode _ h n -> maybe False (== leaf) $ castNode h zeroHeight n
-            _              -> False
+            PageNode h n -> maybe False (== leaf) $ castNode h zeroHeight n
+            _            -> False
  where
    key = Proxy :: Proxy Int64
    val = Proxy :: Proxy Bool
 
-prop_binary_pageNode_idx :: PageSize -> TxId -> Property
-prop_binary_pageNode_idx ps tx = forAll genIndexNode $ \(srcHgt, idx) ->
-    case encodeAndPad ps (PageNode tx srcHgt idx) of
+prop_binary_pageNode_idx :: PageSize -> Property
+prop_binary_pageNode_idx ps = forAll genIndexNode $ \(srcHgt, idx) ->
+    case encodeAndPad ps (PageNode srcHgt idx) of
         Nothing -> True -- too big, skip
         Just bs -> case decode (getPageNode srcHgt key val) bs of
-            PageNode _ h n -> maybe False (== idx) $ castNode h srcHgt n
-            _              -> False
+            PageNode h n -> maybe False (== idx) $ castNode h srcHgt n
+            _            -> False
  where
    key = Proxy :: Proxy Int64
    val = Proxy :: Proxy Bool


### PR DESCRIPTION
- [x] includes tests
- [x] ready for review
- [x] reviewed by @hverr


#### What does this PR do?
- Don't write transaction ids to disk when writing node pages, but keep an in-memory list of freed pages in a write transaction, and use that to reuse pages.

#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
- Next step is writing this in-memory free page list to disk when a transaction is committed.

#### What are the relevant tickets?
