### PR TITLE
Cache more contents of the free tree

### DIFF
--- a/src/Database/Haskey/Alloc/Concurrent/FreePages/Save.hs
+++ b/src/Database/Haskey/Alloc/Concurrent/FreePages/Save.hs
@@ -15,12 +15,11 @@ saveFreePages :: AllocM m
               -> FileState t
               -> m FreeTree
 saveFreePages tx env = saveNewlyFreedPages tx env tree
-                   >>= saveCachedFreePages env
   where
     tree = getSValue $ fileStateFreeTree env
 
 -- | Save the newly free pages of the current transaction, as stored by
--- 'writerNewlyFreedPages'.
+-- 'fileStateNewlyFreedPages'.
 saveNewlyFreedPages :: AllocM m
                     => TxId
                     -> FileState t
@@ -32,18 +31,3 @@ saveNewlyFreedPages tx env tree =
         x:xs -> replaceSubtree tx (x :| xs) tree
   where
     newlyFreed = map (\(NewlyFreed pid) -> pid) $ fileStateNewlyFreedPages env
-
--- | Save the free apges from the free page cache in
--- 'writerReusablePages' using 'writerReuseablePagesTxId'.
-saveCachedFreePages :: AllocM m
-                    => FileState t
-                    -> FreeTree
-                    -> m FreeTree
-saveCachedFreePages env tree = case fileStateReusablePagesTxId env of
-    Nothing -> return tree
-    Just k ->
-        case freePages of
-            [] -> deleteSubtree k tree
-            x:xs -> replaceSubtree k (x :| xs) tree
-  where
-    freePages = map (\(OldFree pid) -> pid) $ fileStateReusablePages env

--- a/src/Database/Haskey/Alloc/Concurrent/Meta.hs
+++ b/src/Database/Haskey/Alloc/Concurrent/Meta.hs
@@ -9,7 +9,6 @@ module Database.Haskey.Alloc.Concurrent.Meta where
 
 import Data.Binary (Binary)
 import Data.Proxy (Proxy)
-import Data.Set as Set
 
 import GHC.Generics (Generic)
 
@@ -33,8 +32,8 @@ data ConcurrentMeta k v = ConcurrentMeta {
   , concurrentMetaDataFreeTree :: S 'TypeData FreeTree
   , concurrentMetaIndexFreeTree :: S 'TypeIndex FreeTree
   , concurrentMetaOverflowTree :: OverflowTree
-  , concurrentMetaDataFreshUnusedPages :: S 'TypeData (Set DirtyFree)
-  , concurrentMetaIndexFreshUnusedPages :: S 'TypeIndex (Set DirtyFree)
+  , concurrentMetaDataCachedFreePages :: S 'TypeData [FreePage]
+  , concurrentMetaIndexCachedFreePages :: S 'TypeIndex [FreePage]
   } deriving (Generic)
 
 deriving instance (Show k, Show v) => Show (ConcurrentMeta k v)

--- a/src/Database/Haskey/Alloc/Concurrent/Monad.hs
+++ b/src/Database/Haskey/Alloc/Concurrent/Monad.hs
@@ -91,7 +91,7 @@ instance
         hnd <- getWriterHnd height
         pid <- getAndTouchPid
 
-        let nid = pageIdToNodeId (getSomeFreePageId pid)
+        let nid = pageIdToNodeId pid
         lift $ putNodePage hnd height nid n
         return nid
       where
@@ -114,14 +114,12 @@ instance
         newTouchedPid = case viewHeight height of
             UZero -> do
                 pid <- fileStateNewNumPages . writerDataFileState <$> get
-                let pid' = FreshFreePage . Fresh <$> pid
-                touchPage pid'
-                return $ getSValue pid'
+                touchPage pid
+                return $ getSValue pid
             USucc _ -> do
                 pid <- fileStateNewNumPages . writerIndexFileState <$> get
-                let pid'' = FreshFreePage . Fresh <$> pid
-                touchPage pid''
-                return $ getSValue pid''
+                touchPage pid
+                return $ getSValue pid
 
 
     freeNode height nid = case viewHeight height of


### PR DESCRIPTION
- [ ] includes tests
- [x] ready for review
- [x] reviewed by @hverr


#### What does this PR do?
- Cache more contents of the free tree between transactions
- This severely increases page reuse, especially when modifying the free tree itself.

#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
