### PR TITLE
Properly remove overflow data marked for deletion from disk 

### DIFF
--- a/haskey.cabal
+++ b/haskey.cabal
@@ -65,7 +65,7 @@ library
     exceptions              >=0.8.3 && <0.9,
     filepath                >=1.4  && <2,
     focus                   >=0.1.2 && <0.2,
-    haskey-btree            >=0.2 && <1,
+    haskey-btree            >=0.2.0.1 && <1,
     list-t                  >=0.2  && <2,
     lz4                     >=0.2  && <1,
     mtl                     >=2.1  && <3,

--- a/src/Database/Haskey/Alloc/Concurrent/Monad.hs
+++ b/src/Database/Haskey/Alloc/Concurrent/Monad.hs
@@ -139,7 +139,9 @@ instance
 
     freeOverflow oid = overflowType oid >>= \case
         Right i -> removeOldOverflow i
-        Left (DirtyOverflow i) -> do
+        Left (DirtyOverflow i) -> deleteOverflowData i
+
+    deleteOverflowData i = do
             root <- concurrentHandlesOverflowDir . writerHnds <$> get
             lift $ removeHandle (getOverflowHandle root i)
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@ resolver: lts-9.0
 packages:
 - '.'
 extra-deps:
-- haskey-btree-0.2.0.0
+- haskey-btree-0.2.0.1
 - lz4-0.2.3.1
 - numerals-0.4.1
 - xxhash-ffi-0.2.0.0


### PR DESCRIPTION
- [ ] includes tests
- [x] ready for review
- [x] reviewed by @hverr

cc: @dfordivam

#### What does this PR do?

This pull request introduces patches to fix issue haskell-haskey/haskey#70.

1. It properly deletes the raw overflow data files from disk, by cleaning up old overflow data when starting a transaction that was marked for deletion in previous transactions.

#### Where should the reviewer start?
#### How should this be manually tested?

See minimal code examples that isolate the issue in haskell-haskey/haskey#70

#### Any background context you want to provide?
#### What are the relevant tickets?
- haskell-haskey/haskey#70
- haskell-haskey/haskey-btree#3